### PR TITLE
(GH-33) Move different subcommands to individual namespaces

### DIFF
--- a/src/Cake.DocFx.Tests/Build/DocFxBuildRunnerFixture.cs
+++ b/src/Cake.DocFx.Tests/Build/DocFxBuildRunnerFixture.cs
@@ -1,4 +1,5 @@
 ﻿using Cake.Core.IO;
+using Cake.DocFx.Build;
 
 namespace Cake.DocFx.Tests.Build
 {

--- a/src/Cake.DocFx.Tests/Init/DocFxInitRunnerFixture.cs
+++ b/src/Cake.DocFx.Tests/Init/DocFxInitRunnerFixture.cs
@@ -1,4 +1,6 @@
-﻿namespace Cake.DocFx.Tests.Init
+﻿using Cake.DocFx.Init;
+
+namespace Cake.DocFx.Tests.Init
 {
     internal sealed class DocFxInitRunnerFixture : DocFxFixture<DocFxInitSettings>
     {

--- a/src/Cake.DocFx/Build/DocFxBuildRunner.cs
+++ b/src/Cake.DocFx/Build/DocFxBuildRunner.cs
@@ -4,7 +4,7 @@ using Cake.Core.IO;
 using Cake.Core.Tooling;
 using Cake.DocFx.Helper;
 
-namespace Cake.DocFx
+namespace Cake.DocFx.Build
 {
     /// <summary>
     /// Command line runner for the 'docfx build' command.

--- a/src/Cake.DocFx/Build/DocFxBuildSettings.cs
+++ b/src/Cake.DocFx/Build/DocFxBuildSettings.cs
@@ -2,7 +2,7 @@
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
-namespace Cake.DocFx
+namespace Cake.DocFx.Build
 {
     /// <summary>
     /// Contains settings used by <see cref="DocFxBuildRunner"/>.

--- a/src/Cake.DocFx/Cake.DocFx.csproj
+++ b/src/Cake.DocFx/Cake.DocFx.csproj
@@ -46,24 +46,28 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="DocFxBuildRunner.cs" />
-    <Compile Include="DocFxBuildSettings.cs" />
+    <Compile Include="Build\DocFxBuildRunner.cs" />
+    <Compile Include="Build\DocFxBuildSettings.cs" />
+    <Compile Include="DocFxMetadataAliases.cs" />
+    <Compile Include="DocFxInitAliases.cs" />
+    <Compile Include="DocFxBuildAliases.cs" />
     <Compile Include="DocFxAliases.cs" />
     <Compile Include="DocFxGlobalMetadata.cs" />
-    <Compile Include="DocFxInitRunner.cs" />
-    <Compile Include="DocFxInitSettings.cs" />
+    <Compile Include="Init\DocFxInitRunner.cs" />
+    <Compile Include="Init\DocFxInitSettings.cs" />
     <Compile Include="DocFxRunner.cs" />
     <Compile Include="DocFxSettings.cs" />
     <Compile Include="DocFxTool.cs" />
     <Compile Include="Helper\Contract.cs" />
-    <Compile Include="DocFxMetadataRunner.cs" />
-    <Compile Include="DocFxMetadataSettings.cs" />
+    <Compile Include="Metadata\DocFxMetadataRunner.cs" />
+    <Compile Include="Metadata\DocFxMetadataSettings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\AssemblyInfo.Static.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Cake.DocFx/DocFxBuildAliases.cs
+++ b/src/Cake.DocFx/DocFxBuildAliases.cs
@@ -2,6 +2,7 @@
 using Cake.Core.Annotations;
 using Cake.Core.IO;
 using Cake.DocFx.Helper;
+using Cake.DocFx.Build;
 
 namespace Cake.DocFx
 {
@@ -9,78 +10,80 @@ namespace Cake.DocFx
     /// Contains functionality related to <see href="http://dotnet.github.io/docfx">DocFx</see>.
     /// </summary>
     [CakeAliasCategory("DocFx")]
-    public static class DocFxAliases
+    [CakeNamespaceImport("Cake.DocFx.Build")]
+    public static class DocFxBuildAliases
     {
         /// <summary>
-        /// Builds DocFx API metadata and markdown files.
+        /// Builds markdown only using DocFx. This will not build API documentation.
         /// </summary>
         /// <param name="context">The Cake context.</param>
         /// <example>
         /// <code>
-        /// DocFx();
+        /// DocFxBuild();
         /// </code>
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Build")]
-        public static void DocFx(this ICakeContext context)
-            => context.DocFx(null, null);
+        public static void DocFxBuild(this ICakeContext context) => context.DocFxBuild(null, null);
 
         /// <summary>
-        /// Builds markdown and API documentation using DocFx.
+        /// Builds markdown only using DocFx. This will not build API documentation.
         /// </summary>
         /// <param name="context">The Cake context.</param>
         /// <param name="configFile">The path to the docfx.json config file.</param>
         /// <example>
         /// <code>
-        /// DocFx("./docs/docfx.json");
+        /// DocFxBuild("./docs/docfx.json");
         /// </code>
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Build")]
-        public static void DocFx(this ICakeContext context, FilePath configFile)
-            => context.DocFx(configFile, null);
+        public static void DocFxBuild(this ICakeContext context, FilePath configFile)
+            => context.DocFxBuild(configFile, null);
 
         /// <summary>
-        /// Builds markdown and API documentation using DocFx, with the specified settings.
+        /// Builds markdown only using DocFx, with the specified settings. This will not build API documentation.
         /// </summary>
         /// <param name="context">The Cake context.</param>
         /// <param name="settings">The DocFx settings.</param>
         /// <example>
         /// <code>
-        /// DocFx(new DocFxSettings()
+        /// DocFxBuild(new DocFxBuildSettings()
         /// {
-        ///     OutputPath = "./artifacts/docs"
+        ///     OutputPath = "./artifacts/docs",
+        ///     TemplateFolder = "default"
         /// });
         /// </code>
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Build")]
-        public static void DocFx(this ICakeContext context, DocFxSettings settings)
-            => context.DocFx(null, settings);
+        public static void DocFxBuild(this ICakeContext context, DocFxBuildSettings settings)
+            => context.DocFxBuild(null, settings);
 
         /// <summary>
-        /// Builds markdown and API documentation using DocFx, with the specified settings.
+        /// Builds markdown only using DocFx, with the specified settings. This will not build API documentation.
         /// </summary>
         /// <param name="context">The Cake context.</param>
         /// <param name="configFile">The path to the docfx.json config file.</param>
         /// <param name="settings">The DocFx settings.</param>
         /// <example>
         /// <code>
-        /// DocFx("./docs/docfx.json", new DocFxSettings()
+        /// DocFxBuild("./docs/docfx.json", new DocFxBuildSettings()
         /// {
-        ///     OutputPath = "./artifacts/docs"
+        ///     OutputPath = "./artifacts/docs",
+        ///     TemplateFolder = "default"
         /// });
         /// </code>
         /// </example>
         [CakeMethodAlias]
         [CakeAliasCategory("Build")]
-        public static void DocFx(this ICakeContext context, FilePath configFile, DocFxSettings settings)
+        public static void DocFxBuild(this ICakeContext context, FilePath configFile, DocFxBuildSettings settings)
         {
             Contract.NotNull(context, nameof(context));
 
-            settings = settings ?? new DocFxSettings();
+            settings = settings ?? new DocFxBuildSettings();
 
-            var runner = new DocFxRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            var runner = new DocFxBuildRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             runner.Run(configFile, settings);
         }
     }

--- a/src/Cake.DocFx/DocFxInitAliases.cs
+++ b/src/Cake.DocFx/DocFxInitAliases.cs
@@ -1,0 +1,63 @@
+﻿using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.DocFx.Helper;
+using Cake.DocFx.Init;
+
+namespace Cake.DocFx
+{
+    /// <summary>
+    /// Contains functionality related to <see href="http://dotnet.github.io/docfx">DocFx</see>.
+    /// </summary>
+    [CakeAliasCategory("DocFx")]
+    [CakeNamespaceImport("Cake.DocFx.Build")]
+    public static class DocFxInitAliases
+    {
+        /// <summary>
+        /// Generate an initial <code>docfx.json</code> file.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <example>
+        /// <code>
+        /// DocFxInit();
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Init")]
+        public static void DocFxInit(this ICakeContext context)
+            => context.DocFxInit((DocFxInitSettings)null);
+
+        /// <summary>
+        /// Generate an initial <code>docfx.json</code> file, with the specified settings.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <param name="settings">The DocFx settings.</param>
+        /// <example>
+        /// <code>
+        /// DocFxInit(new DocFxInitSettings()
+        /// {
+        ///     OutputPath = "./docs"
+        /// });
+        /// </code>
+        /// </example>
+        /// <example>
+        /// <code>
+        /// DocFxInit(new DocFxInitSettings()
+        /// {
+        ///     OutputPath = "./docs",
+        ///     OnlyConfigFile = true
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Init")]
+        public static void DocFxInit(this ICakeContext context, DocFxInitSettings settings)
+        {
+            Contract.NotNull(context, nameof(context));
+
+            settings = settings ?? new DocFxInitSettings();
+
+            var runner = new DocFxInitRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run(settings);
+        }
+    }
+}

--- a/src/Cake.DocFx/DocFxMetadataAliases.cs
+++ b/src/Cake.DocFx/DocFxMetadataAliases.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+using Cake.DocFx.Helper;
+using Cake.DocFx.Metadata;
+
+namespace Cake.DocFx
+{
+    /// <summary>
+    /// Contains functionality related to <see href="http://dotnet.github.io/docfx">DocFx</see>.
+    /// </summary>
+    [CakeAliasCategory("DocFx")]
+    [CakeNamespaceImport("Cake.DocFx.Metadata")]
+    public static class DocFxMetadataAliases
+    {
+        /// <summary>
+        /// Extract API documentation using DocFx.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <example>
+        /// <code>
+        /// DocFxMetadata();
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Metadata")]
+        public static void DocFxMetadata(this ICakeContext context)
+            => context.DocFxMetadata((DocFxMetadataSettings) null);
+
+        /// <summary>
+        /// Extract API documentation using DocFx.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <param name="configFile">The path to the docfx.json config file.</param>
+        /// <example>
+        /// <code>
+        /// DocFxMetadata("./docs/docfx.json");
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Metadata")]
+        public static void DocFxMetadata(this ICakeContext context, FilePath configFile)
+        {
+            context.DocFxMetadata(new DocFxMetadataSettings
+            {
+                Projects = new[] {configFile}
+            });
+        }
+
+        /// <summary>
+        /// Extract API documentation using DocFx, with the specified project/source files or search patterns.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <param name="files">The project or source files, or search patterns.</param>
+        /// <example>
+        /// <code>
+        /// var files = GetFiles("./src/**/*.csproj");
+        /// DocFxMetadata(files);
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Metadata")]
+        public static void DocFxMetadata(this ICakeContext context, IEnumerable<FilePath> files)
+        {
+            context.DocFxMetadata(new DocFxMetadataSettings
+            {
+                Projects = files
+            });
+        }
+
+        /// <summary>
+        /// Extract API documentation using DocFx, with the specified settings.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <param name="settings">The DocFx settings.</param>
+        /// <example>
+        /// <code>
+        /// DocFxMetadata(new DocFxMetadataSettings()
+        /// {
+        ///     OutputPath = "./artifacts/docs"
+        /// });
+        /// </code>
+        /// </example>
+        /// <example>
+        /// <code>
+        /// DocFxMetadata(new DocFxMetadataSettings()
+        /// {
+        ///     OutputPath = "./artifacts/docs",
+        ///     Projects = GetFiles("./src/**/*.csproj")
+        /// });
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Metadata")]
+        public static void DocFxMetadata(this ICakeContext context, DocFxMetadataSettings settings)
+        {
+            Contract.NotNull(context, nameof(context));
+
+            settings = settings ?? new DocFxMetadataSettings();
+
+            var runner = new DocFxMetadataRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Run(settings);
+        }
+    }
+}

--- a/src/Cake.DocFx/Init/DocFxInitRunner.cs
+++ b/src/Cake.DocFx/Init/DocFxInitRunner.cs
@@ -3,7 +3,7 @@ using Cake.Core.IO;
 using Cake.Core.Tooling;
 using Cake.DocFx.Helper;
 
-namespace Cake.DocFx
+namespace Cake.DocFx.Init
 {
     /// <summary>
     /// Command line runner for the 'docfx init' command.

--- a/src/Cake.DocFx/Init/DocFxInitSettings.cs
+++ b/src/Cake.DocFx/Init/DocFxInitSettings.cs
@@ -1,7 +1,7 @@
 ﻿using Cake.Core.IO;
 using Cake.Core.Tooling;
 
-namespace Cake.DocFx
+namespace Cake.DocFx.Init
 {
     /// <summary>
     /// Contains settings used by <see cref="DocFxInitRunner"/>.

--- a/src/Cake.DocFx/Metadata/DocFxMetadataRunner.cs
+++ b/src/Cake.DocFx/Metadata/DocFxMetadataRunner.cs
@@ -3,7 +3,7 @@ using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
-namespace Cake.DocFx
+namespace Cake.DocFx.Metadata
 {
     /// <summary>
     /// Command line runner for the 'docfx metadata' command.

--- a/src/Cake.DocFx/Metadata/DocFxMetadataSettings.cs
+++ b/src/Cake.DocFx/Metadata/DocFxMetadataSettings.cs
@@ -2,7 +2,7 @@
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
-namespace Cake.DocFx
+namespace Cake.DocFx.Metadata
 {
     /// <summary>
     /// Contains settings used by <see cref="DocFxMetadataRunner"/>.


### PR DESCRIPTION
Move code for the different subcommands of docfx to individual namespaces.

Fixes #33