### PR TITLE
(GH-26) Add support for docfx build --serve

### DIFF
--- a/src/Cake.DocFx.Tests/Build/DocFxBuildRunnerTests.cs
+++ b/src/Cake.DocFx.Tests/Build/DocFxBuildRunnerTests.cs
@@ -35,6 +35,22 @@
                 // Then
                 Assert.Equal("build --globalMetadata \"{\\\"foo\\\": \\\"bar\\\"}\"", result.Args);
             }
+
+            [Fact]
+            public void Should_Add_Serve_To_Arguments_If_True()
+            {
+                // Given
+                var fixture = new DocFxBuildRunnerFixture
+                {
+                    Settings = {Serve = true}
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("build --serve", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.DocFx/DocFxBuildRunner.cs
+++ b/src/Cake.DocFx/DocFxBuildRunner.cs
@@ -57,6 +57,11 @@ namespace Cake.DocFx
                     "--globalMetadata \"{{{0}}}\"",
                     string.Join(", ", settings.GlobalMetadata.Select(x => $"\\\"{x.Key}\\\": \\\"{x.Value}\\\"")));
 
+            if (settings.Serve)
+            {
+                builder.Append("--serve");
+            }
+
             return builder;
         }
     }

--- a/src/Cake.DocFx/DocFxBuildSettings.cs
+++ b/src/Cake.DocFx/DocFxBuildSettings.cs
@@ -29,5 +29,11 @@ namespace Cake.DocFx
         /// See <see cref="DocFxGlobalMetadata"/> for constants for metadata keys.
         /// </summary>
         public Dictionary<string, string> GlobalMetadata => _globalMetadata;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable previewing of the generated documentation
+        /// in a built in web server. 
+        /// </summary>
+        public bool Serve { get; set; }
     }
 }


### PR DESCRIPTION
Add support for `docfx build --serve`.

Fixes #26 

Requires #31 and being rebased afterwards