### PR TITLE
(GH-51) Remove obsolete attribute since it raises a warning on Linux

### DIFF
--- a/src/Cake.DocFx/DocFxSettings.cs
+++ b/src/Cake.DocFx/DocFxSettings.cs
@@ -7,7 +7,6 @@ namespace Cake.DocFx
     /// <summary>
     /// Obsolete use aliases from <see cref="DocFxBuildAliases"/> instead.
     /// </summary>
-    [Obsolete("Use DocFxBuild instead.")]
     public class DocFxSettings : ToolSettings
     {
         /// <summary>


### PR DESCRIPTION
Remove obsolete attribute on settings class since it raises a warning on Linux

Fixes #51 