### PR TITLE
(GH-58) Upgrade to Cake 0.23.0

### DIFF
--- a/setup.cake
+++ b/setup.cake
@@ -8,7 +8,8 @@ BuildParameters.SetParameters(context: Context,
                             title: "Cake.DocFx",
                             repositoryOwner: "cake-contrib",
                             repositoryName: "Cake.DocFx",
-                            appVeyorAccountName: "cakecontrib");
+                            appVeyorAccountName: "cakecontrib",
+                            shouldRunCodecov: false);
 
 BuildParameters.PrintParameters(Context);
 

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Cake" version="0.18.0" />
+	<package id="Cake" version="0.23.0" />
 </packages>


### PR DESCRIPTION
Update to Cake 0.23.0 for compatibility with latest Cake.Recipe

Fixes #58 