### PR TITLE
(GH-75) Support path with space for DocFxMetadata

### DIFF
--- a/src/Cake.DocFx.Tests/Metadata/DocFxMetadataRunnerTests.cs
+++ b/src/Cake.DocFx.Tests/Metadata/DocFxMetadataRunnerTests.cs
@@ -1,4 +1,6 @@
-﻿using Xunit;
+﻿using Cake.Core.IO;
+using System.Collections.Generic;
+using Xunit;
 
 namespace Cake.DocFx.Tests.Metadata
 {
@@ -20,6 +22,77 @@ namespace Cake.DocFx.Tests.Metadata
 
                 // Then
                 result.IsArgumentNullException("settings");
+            }
+
+            [Fact]
+            public void Should_Add_Project_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new DocFxMetadataRunnerFixture
+                {
+                    Settings = { Projects = new List<FilePath> { @"c:\temp\docfx.json" }  }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("metadata \"c:/temp/docfx.json\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Project_With_Space_In_Path_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new DocFxMetadataRunnerFixture
+                {
+                    Settings = { Projects = new List<FilePath> { @"c:\foo bar\docfx.json" } }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("metadata \"c:/foo bar/docfx.json\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_Multiple_Projects_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new DocFxMetadataRunnerFixture
+                {
+                    Settings =
+                    {
+                        Projects = new List<FilePath>
+                        {
+                            @"c:\temp\foo.csproj",
+                            @"c:\temp\bar.csproj"
+                        }
+                    }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("metadata \"c:/temp/foo.csproj\",\"c:/temp/bar.csproj\"", result.Args);
+            }
+
+            [Fact]
+            public void Should_Add_OutputPath_To_Arguments_If_Set()
+            {
+                // Given
+                var fixture = new DocFxMetadataRunnerFixture
+                {
+                    Settings = { OutputPath = @"c:\temp\api" }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("metadata -o \"c:/temp/api\"", result.Args);
             }
 
             [Fact]

--- a/src/Cake.DocFx/Metadata/DocFxMetadataRunner.cs
+++ b/src/Cake.DocFx/Metadata/DocFxMetadataRunner.cs
@@ -43,7 +43,7 @@ namespace Cake.DocFx.Metadata
 
             // parameters
             if (settings.Projects != null && settings.Projects.Any())
-                builder.Append(string.Join(",", settings.Projects.Select(val => val.FullPath)));
+                builder.Append(string.Join(",", settings.Projects.Select(val => "\"" + val.FullPath + "\"")));
 
             #region DupFinder Exclusion
             if (settings.OutputPath != null)

--- a/src/Cake.DocFx/Metadata/DocFxMetadataSettings.cs
+++ b/src/Cake.DocFx/Metadata/DocFxMetadataSettings.cs
@@ -10,19 +10,30 @@ namespace Cake.DocFx.Metadata
     public class DocFxMetadataSettings : ToolSettings
     {
         /// <summary>
-        ///     Specifies the projects to have metadata extracted. There are several approaches to extract language metadata.
-        ///     1. From a supported project file or project file list
-        ///         Supported project file extensions include .csproj, .vbproj, .sln.
-        ///     2. From a supported source code file or source code file list
-        ///         Supported source code file extensions include .cs and .vb. Files can be combined using , as seperator and search
-        ///     pattern.
-        ///     3. From docfx.json file. If the argument is not specified, docfx.exe will try reading docfx.json under current
-        ///     directory.
+        /// Specifies the projects to have metadata extracted. There are several approaches to extract language metadata.
+        /// <list type="number">
+        /// <item>
+        /// <description>
+        /// From a supported project file or project file list.
+        /// Supported project file extensions include .csproj, .vbproj, .sln.
+        /// </description>
+        /// </item>
+        /// <item>
+        /// <description>
+        /// From a supported source code file or source code file list. 
+        /// Supported source code file extensions include .cs and .vb. Files can be combined using , as seperator and search pattern.
+        /// </description>
+        /// </item>
+        /// <item>
+        /// <description>From docfx.json file.</description>
+        /// </item>
+        /// </list>
+        /// If the argument is not specified, docfx.exe will try reading docfx.json under current directory.
         /// </summary>
         public IEnumerable<FilePath> Projects { get; set; }
 
         /// <summary>
-        /// Gets or sets the output folder. The default is api, and is configured in the 'metadata' section of docfx.json.
+        /// Gets or sets the output folder. The default is <c>api</c>, and is configured in the 'metadata' section of docfx.json.
         /// </summary>
         public DirectoryPath OutputPath { get; set; }
 


### PR DESCRIPTION
Support path with space for `DocFxMetadata` alias

Fixes #75 