### PR TITLE
(GH-84) Add support of --warningsAsErrors build parameter

### DIFF
--- a/src/Cake.DocFx.Tests/Build/DocFxBuildRunnerTests.cs
+++ b/src/Cake.DocFx.Tests/Build/DocFxBuildRunnerTests.cs
@@ -119,6 +119,23 @@ namespace Cake.DocFx.Tests.Build
                 // Then
                 Assert.Equal("build --force", result.Args);
             }
+
+
+            [Fact]
+            public void Should_Add_WarningsAsErrors_To_Arguments_If_True()
+            {
+                // Given
+                var fixture = new DocFxBuildRunnerFixture
+                {
+                    Settings = { WarningsAsErrors = true }
+                };
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                Assert.Equal("build --warningsAsErrors", result.Args);
+            }
         }
     }
 }

--- a/src/Cake.DocFx/Build/DocFxBuildRunner.cs
+++ b/src/Cake.DocFx/Build/DocFxBuildRunner.cs
@@ -75,6 +75,11 @@ namespace Cake.DocFx.Build
                 builder.Append("--force");
             }
 
+            if (settings.WarningsAsErrors)
+            {
+                builder.Append("--warningsAsErrors");
+            }
+
             return builder;
         }
     }

--- a/src/Cake.DocFx/Build/DocFxBuildSettings.cs
+++ b/src/Cake.DocFx/Build/DocFxBuildSettings.cs
@@ -50,5 +50,10 @@ namespace Cake.DocFx.Build
         /// Gets or sets a value indicating whether all the documentation is re-build.
         /// </summary>
         public bool Force { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether all warnings must be seen as errors
+        /// </summary>
+        public bool WarningsAsErrors { get; set; }
     }
 }


### PR DESCRIPTION
Add the support of --warningsAsErrors build parameter to CI cake build can fail if we have warnings 

Fixes #84 