### PR TITLE
Change Cake.Core Dependency to 2.0.0+

### DIFF
--- a/nuspec/nuget/Cake.DocFx.nuspec
+++ b/nuspec/nuget/Cake.DocFx.nuspec
@@ -19,8 +19,8 @@
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />
-    <file src="netstandard2.0\Cake.DocFx.dll" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.DocFx.pdb" target="lib\netstandard2.0" />
-    <file src="netstandard2.0\Cake.DocFx.xml" target="lib\netstandard2.0" />
+    <file src="net5.0\Cake.DocFx.dll" target="lib\net5.0" />
+    <file src="net5.0\Cake.DocFx.pdb" target="lib\net5.0" />
+    <file src="net5.0\Cake.DocFx.xml" target="lib\net5.0" />
   </files>
 </package>

--- a/nuspec/nuget/Cake.DocFx.nuspec
+++ b/nuspec/nuget/Cake.DocFx.nuspec
@@ -15,7 +15,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <copyright>Copyright (c) Cake Contributions 2016 - Present</copyright>
     <tags>cake cake-addin docfx</tags>
-    <releaseNotes>https://github.com/cake-contrib/Cake.DocFx/releases/tag/1.0.0</releaseNotes>
+    <releaseNotes>https://github.com/cake-contrib/Cake.DocFx/releases/tag/2.0.0</releaseNotes>
   </metadata>
   <files>
     <file src="..\..\..\..\nuspec\nuget\icon.png" target="" />

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:?package=Cake.Recipe&version=1.0.0
+#load nuget:?package=Cake.Recipe&version=2.2.1
 
 Environment.SetVariableNames();
 

--- a/src/Cake.DocFx.Tests/Cake.DocFx.Tests.csproj
+++ b/src/Cake.DocFx.Tests/Cake.DocFx.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Description>Tests for the Cake.DocFx addin</Description>
     <Authors>Paul Reichelt and contributors</Authors>
@@ -18,8 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Cake.Core" Version="1.0.0" />
-    <PackageReference Include="Cake.Testing" Version="1.0.0" />
+    <PackageReference Include="Cake.Core" Version="2.*" />
+    <PackageReference Include="Cake.Testing" Version="2.*" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Cake.DocFx.Tests/Cake.DocFx.Tests.csproj
+++ b/src/Cake.DocFx.Tests/Cake.DocFx.Tests.csproj
@@ -11,6 +11,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Properties\**" />
+    <EmbeddedResource Remove="Properties\**" />
+    <None Remove="Properties\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Cake.Core" Version="1.0.0" />
     <PackageReference Include="Cake.Testing" Version="1.0.0" />
@@ -23,9 +29,5 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Cake.DocFx\Cake.DocFx.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
 </Project>

--- a/src/Cake.DocFx.Tests/Cake.DocFx.Tests.csproj
+++ b/src/Cake.DocFx.Tests/Cake.DocFx.Tests.csproj
@@ -17,11 +17,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Cake.Core" Version="1.0.0" />
     <PackageReference Include="Cake.Testing" Version="1.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Cake.DocFx/Cake.DocFx.csproj
+++ b/src/Cake.DocFx/Cake.DocFx.csproj
@@ -14,12 +14,12 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\Cake.DocFx.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net5.0|AnyCPU'">
+    <DocumentationFile>bin\Debug\net5.0\Cake.DocFx.xml</DocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Cake.DocFx.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net5.0|AnyCPU'">
+    <DocumentationFile>bin\Release\net5.0\Cake.DocFx.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Cake.DocFx/Cake.DocFx.csproj
+++ b/src/Cake.DocFx/Cake.DocFx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <Description>Cake Addin providing DocFx support</Description>
     <Authors>Paul Reichelt and contributors</Authors>
     <Company></Company>
@@ -23,6 +23,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="1.0.0" />
+	  <PackageReference Include="Cake.Core" Version="2.*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description
During my usage of this Cake plugin, I noticed the following warning message:
The assembly 'Cake.DocFx, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'
is referencing an older version of Cake.Core (1.0.0).
For best compatibility it should target Cake.Core version 2.0.0.

I decided to see if I couldn't fork your repo and add support for Cake.Sure 2.0.0.

I was able to update the dependencies, and the projects compile fine in Visual Studio.  But the Cake Build recipe is now broken.  I had to update the solution projects to net5.0 in order to adopt Cake.Core 2+, and it looks like the Cake dependencies in the plugin's build script only support netcoreapp.  I do not have time to take the work further without instruction, but **_if you can provide guidance to solve those problems, I'll spend some more time and see what I can do_**.

## Related Issue
[Latest Cake Build emits warning: The assembly 'Cake.DocFx, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null' is referencing an older version of Cake.Core (1.0.0). For best compatibility it should target Cake.Core version 2.0.0.](https://github.com/cake-contrib/Cake.DocFx/issues/105)

## Motivation and Context
I'm mostly trying to be helpful.

## How Has This Been Tested?
See the description.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Breaking change - If following semantic versions, this would require a new major version, as the TargetFramework had to be updated.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. - I'm happy to do so with some guidance.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
